### PR TITLE
Add new create service page button

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Use the following command in code:
 browser.debug()
 ```
 
+Or use the npm script:
+
+```bash
+npm run test-local:debug
+```
+
 ## Test suite requirements
 
 - mongodb

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "wdio run ./wdio.conf.js",
     "test-local": "wdio run ./wdio.local.conf.js",
+    "test-local:debug": "DEBUG=true npm run test-local",
     "format": "prettier --write 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "lint": "eslint .",

--- a/test/specs/create-microservice.e2e.js
+++ b/test/specs/create-microservice.e2e.js
@@ -90,7 +90,7 @@ describe('Create microservice', () => {
 
   it('Should be redirected to create microservice status page', async () => {
     await expect(browser).toHaveTitle(
-      `${testRepositoryName} microservice | Core Delivery Platform - Portal`
+      `Creating ${testRepositoryName} microservice | Core Delivery Platform - Portal`
     )
     await expect(await ServicesPage.navIsActive()).toBe(true)
     await expect(ServicesPage.appHeadingTitle(testRepositoryName)).toExist()
@@ -100,13 +100,21 @@ describe('Create microservice', () => {
       )
     ).toExist()
     await expect(ServicesPage.overallProgress()).toHaveText('IN PROGRESS')
+  })
 
-    await ServicesPage.overallProgress('Success').waitForDisplayed({
-      timeout: 20000,
-      timeoutMsg: 'Expected overall status to be successful after 20 seconds'
-    })
+  it('Should be redirected to "success" create microservice page', async () => {
+    await expect(browser).toHaveTitle(
+      `Created ${testRepositoryName} microservice | Core Delivery Platform - Portal`
+    )
+    await expect(await ServicesPage.navIsActive()).toBe(true)
+    await expect(ServicesPage.appHeadingTitle(testRepositoryName)).toExist()
+    await expect(
+      ServicesPage.appHeadingCaption(
+        `Created the ${testRepositoryName} microservice.`
+      )
+    ).toExist()
 
-    await expect(ServicesPage.overallProgress()).toHaveText('SUCCESS')
+    await FromComponent.submitButton('View microservice page').click()
   })
 
   it('Should be redirected to created microservice page', async () => {


### PR DESCRIPTION
## Over the Christmas period
> I am back on the 8th Jan 2024 I can merge then or @flurdy or @christopherjturner feel free to have a look over and merge if your happy. It would be nice for this work not to go stale


## Description
User Journey Tests for the new create service flow with a button to pause on the status page. This makes the Integration tests (need to update the name of this job to `User Journey Tests`) to ✅ 

## Associated PRs
- https://github.com/DEFRA/cdp-portal-frontend/pull/262
- https://github.com/DEFRA/cdp-self-service-ops/pull/135
